### PR TITLE
parse Number inputs as floats

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,7 @@ FormSyphon = {
       return $el.val();
     },
     number: function($el) {
-      return parseInt($el.val());
+      return parseFloat($el.val());
     },
     checkbox: function($el) {
       return $el.prop("checked");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "form-syphon",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Serializes and deserializes all input elements in a container element.",
   "main": "lib/index.js",
   "repository": {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -110,7 +110,7 @@ FormSyphon =
       return $el.val()
 
     number : ($el) ->
-      return parseInt($el.val())
+      return parseFloat($el.val())
 
     checkbox : ($el) ->
       return $el.prop("checked")


### PR DESCRIPTION
`<input type="number">` contains float numbers. The `step` can be set to `any` or a specific decimal value. FormSyphon should return these correctly and not cast them to `int`.
